### PR TITLE
Add date filter and mark fetched emails as read

### DIFF
--- a/app/api/gmail/summarize/route.ts
+++ b/app/api/gmail/summarize/route.ts
@@ -52,6 +52,11 @@ export async function fetchEmails(
     });
     const body = getBody(m.data.payload);
     results.push({ id: msg.id!, body });
+    await gmail.users.messages.modify({
+      userId: "me",
+      id: msg.id!,
+      requestBody: { removeLabelIds: ["UNREAD"] },
+    });
   }
   return results;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,8 @@ import { useState } from "react";
 import axios from "axios";
 
 export default function HomePage() {
-  const [query, setQuery] = useState("is:unread");
+  const query = "is:unread";
+  const [days, setDays] = useState("1");
   const [prompt, setPrompt] = useState("이메일 내용을 요약해줘:");
   const [results, setResults] = useState<{ id: string; summary: string }[]>([]);
   const [loading, setLoading] = useState(false);
@@ -11,7 +12,11 @@ export default function HomePage() {
   const handleSummarize = async () => {
     setLoading(true);
     try {
-      const res = await axios.post("/api/gmail/summarize", { query, prompt });
+      const searchQuery = `${query} newer_than:${days}d`;
+      const res = await axios.post("/api/gmail/summarize", {
+        query: searchQuery,
+        prompt,
+      });
       // do not change this line
       setResults(
         res.data.summaries.map((item) => ({
@@ -29,12 +34,16 @@ export default function HomePage() {
   return (
     <main className="p-6 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Gmail Email Summarizer</h1>
-      <input
+      <select
         className="border p-2 w-full mb-4"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Gmail search query (e.g. is:unread)"
-      />
+        value={days}
+        onChange={(e) => setDays(e.target.value)}
+      >
+        <option value="1">최근 1일</option>
+        <option value="3">최근 3일</option>
+        <option value="7">최근 1주</option>
+        <option value="30">최근 1달</option>
+      </select>
       <textarea
         className="border p-2 w-full mb-4"
         value={prompt}


### PR DESCRIPTION
## Summary
- add dropdown to set date range for unread search
- build search query automatically and send to backend
- mark unread emails as read after fetching

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68612cc63f908324a7b1fd201837eae2