### PR TITLE
Add calendar summarizer

### DIFF
--- a/app/api/calendar/summarize/route.ts
+++ b/app/api/calendar/summarize/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+
+const oAuth2Client = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+oAuth2Client.setCredentials({
+  refresh_token: process.env.GOOGLE_REFRESH_TOKEN,
+});
+export const calendar = google.calendar({ version: "v3", auth: oAuth2Client });
+
+async function fetchEvents(date: string) {
+  const start = new Date(date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+  const res = await calendar.events.list({
+    calendarId: "primary",
+    timeMin: start.toISOString(),
+    timeMax: end.toISOString(),
+    singleEvents: true,
+    orderBy: "startTime",
+  });
+  return res.data.items || [];
+}
+
+export async function summarizeWithGemini(text: string, prompt: string) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${process.env.GEMINI_API_KEY}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        contents: [
+          {
+            parts: [
+              {
+                text: `${prompt}\n${text}`,
+              },
+            ],
+          },
+        ],
+      }),
+    }
+  );
+  const data = await res.json();
+  return data.candidates?.[0]?.content ?? "";
+}
+
+export async function POST(request: Request) {
+  const { date, prompt } = await request.json();
+  if (!date) {
+    return NextResponse.json({ error: "Missing date parameter" }, { status: 400 });
+  }
+  try {
+    const events = await fetchEvents(date);
+    const text = events
+      .map((e) => `${e.start?.dateTime || e.start?.date} - ${e.summary}`)
+      .join("\n");
+    const summaryPrompt = prompt || "아래 일정들을 요약해줘:";
+    const summary = await summarizeWithGemini(text, summaryPrompt);
+    return NextResponse.json({ summary });
+  } catch (error: any) {
+    console.error("Error summarizing calendar:", error);
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useState } from "react";
+import axios from "axios";
+
+export default function CalendarPage() {
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [prompt, setPrompt] = useState("아래 일정들을 요약해줘:");
+  const [summary, setSummary] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSummarize = async () => {
+    setLoading(true);
+    try {
+      const res = await axios.post("/api/calendar/summarize", {
+        date,
+        prompt,
+      });
+      setSummary(res.data.summary);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="p-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Calendar Summarizer</h1>
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="border p-2 w-full mb-4"
+      />
+      <textarea
+        className="border p-2 w-full mb-4"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        placeholder="Summary prompt"
+        rows={3}
+      />
+      <button
+        onClick={handleSummarize}
+        disabled={loading}
+        className="bg-blue-600 text-white px-4 py-2 rounded mb-6"
+      >
+        {loading ? "Summarizing..." : "Summarize Events"}
+      </button>
+      {summary && <p className="border p-4 rounded whitespace-pre-wrap">{summary}</p>}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route to summarize events from Google Calendar
- add a page with date input to query calendar summary

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686130fc67bc8324b94a94a891522deb