### PR TITLE
Implement login-based OAuth flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+Before using the Gmail or Calendar summarizers, visit `/login` to authorize the
+app with Google. The refresh token will be stored in a cookie instead of a
+`.env` file.
+
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+
+const oAuth2Client = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  if (!code) {
+    return NextResponse.json({ error: "Missing code" }, { status: 400 });
+  }
+
+  const { tokens } = await oAuth2Client.getToken(code);
+  const res = NextResponse.redirect(new URL("/", request.url));
+  if (tokens.refresh_token) {
+    res.cookies.set("refresh_token", tokens.refresh_token, {
+      httpOnly: true,
+      path: "/",
+    });
+  }
+  return res;
+}

--- a/app/api/auth/url/route.ts
+++ b/app/api/auth/url/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { google } from "googleapis";
+
+const oAuth2Client = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+  process.env.GOOGLE_REDIRECT_URI
+);
+
+export async function GET() {
+  const url = oAuth2Client.generateAuthUrl({
+    access_type: "offline",
+    scope: [
+      "https://www.googleapis.com/auth/gmail.readonly",
+      "https://www.googleapis.com/auth/calendar.readonly",
+    ],
+    prompt: "consent",
+  });
+  return NextResponse.json({ url });
+}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -16,7 +16,11 @@ export default function CalendarPage() {
         prompt,
       });
       setSummary(res.data.summary);
-    } catch (err) {
+    } catch (err: any) {
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        window.location.href = "/login";
+        return;
+      }
       console.error(err);
     } finally {
       setLoading(false);

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useEffect } from "react";
+
+export default function LoginPage() {
+  useEffect(() => {
+    const go = async () => {
+      const res = await fetch("/api/auth/url");
+      const data = await res.json();
+      window.location.href = data.url;
+    };
+    go();
+  }, []);
+
+  return <p>Redirecting to Google login...</p>;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,7 +24,11 @@ export default function HomePage() {
           summary: item.summary.parts?.[0].text,
         }))
       );
-    } catch (err) {
+    } catch (err: any) {
+      if (axios.isAxiosError(err) && err.response?.status === 401) {
+        window.location.href = "/login";
+        return;
+      }
       console.error(err);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- add auth URL and callback API routes
- store refresh token in cookie via login page
- update Gmail and Calendar handlers to read refresh token from cookie
- redirect to login page on 401 errors
- document new login procedure

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686138bc620c83249d9fc0ec4b030431