### PR TITLE
Fix OAuth callback

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,12 +3,21 @@ import { useEffect } from "react";
 
 export default function LoginPage() {
   useEffect(() => {
-    const go = async () => {
-      const res = await fetch("/api/auth/url");
-      const data = await res.json();
-      window.location.href = data.url;
-    };
-    go();
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("code")) {
+      const finish = async () => {
+        await fetch(`/api/auth/callback?${params.toString()}`);
+        window.location.href = "/";
+      };
+      finish();
+    } else {
+      const go = async () => {
+        const res = await fetch("/api/auth/url");
+        const data = await res.json();
+        window.location.href = data.url;
+      };
+      go();
+    }
   }, []);
 
   return <p>Redirecting to Google login...</p>;


### PR DESCRIPTION
## Summary
- handle OAuth code on login page to invoke callback and set cookie

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68613ed2fde483248f44f3c5ca25af74